### PR TITLE
Add annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@
     # URL to a custom configuration (`.luacheckrc`) file that will be used as
     # the default configuration file.
     config: ''
+
+    # Emits annotations for source code at locations parsed from the output.
+    # Must be set to "none", "warning" or "error".
+    #
+    # Requires that output of warnings not be suppressed through the -qq or -qqq arguments.
+    #
+    # Default: 'none'
+    annotate: 'none'
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,14 @@ inputs:
       URL to a custom configuration (`.luacheckrc`) file that will be
       used as the default configuration file.
     required: false
+  annotate:
+    description: >
+      Emits annotations for source code at locations parsed from the output.
+      Must be set to "none", "warning" or "error".
+
+      Requires that output of warnings not be suppressed through the -qq or -qqq arguments.
+    required: false
+    default: none
 runs:
   using: composite
   steps:
@@ -51,6 +59,28 @@ runs:
           exit 1
         }
       shell: bash
-    - run: luacheck ${{ inputs.args }} -- ${{ inputs.files }}
+    - run: |
+        annotate() {
+          case "${{ inputs.annotate }}" in
+            warning|error)
+              # Search for "<path>:<line>:<col>: <message>" lines in the output,
+              # trim whitespace, and reformat them to workflow commands.
+              awk -F':' -v level="${{ inputs.annotate }}" '
+                { print $0 }
+
+                /^\s+.+?:[0-9]+:[0-9]+:/ {
+                  gsub(/^\s+|\s+$/, "")
+                  gsub(/^\s+/, "", $4)
+
+                  printf "::%s file=%s,line=%s,col=%s::%s\n", level, $1, $2, $3, $4
+                }'
+                ;;
+            *)
+              cat
+              ;;
+          esac
+        }
+
+        luacheck ${{ inputs.args }} -- ${{ inputs.files }} | annotate
       working-directory: ${{ inputs.path }}
       shell: bash


### PR DESCRIPTION
This adds a new (off-by-default) option to emit warning/error annotations for source code based upon the messages output by luacheck. These can be browsed either through the annotations section present on a run in the "Actions" tab, or in-line with source code when a check is executed against a PR as seen below.

![image](https://user-images.githubusercontent.com/287102/96153917-23d03480-0f06-11eb-899a-47b0eb3c3143.png)

I've got a few dummy action runs demonstrating how this behaves and looks from the "Actions" tab standpoint.

[The first check](https://github.com/Meorawr/Total-RP-3/runs/1259979581?check_suite_focus=true) is what happens if the new `annotate` option is left unspecified (which defaults to "none"). This retains compatibility with what users of the action might already be expecting in their action log outputs by not creating any annotations for the source code and writing out the full log unmodified.

[The second check](https://github.com/Meorawr/Total-RP-3/runs/1259989248?check_suite_focus=true) sets the `annotate` option to `error` which will cause each issue found by luacheck to generate an error level annotation (as noted by the lovely red lines in the log), which will show up on the [landing page of the action run itself](https://github.com/Meorawr/Total-RP-3/actions/runs/308912615).

[The third check](https://github.com/Meorawr/Total-RP-3/runs/1260001396?check_suite_focus=true) is the same but at a `warning` level instead, in case users have an inexplicable fear of the colour red. This behaves the same way as `error` above, it's just a visual difference.

Also just for completeness, [here's a fourth check](https://github.com/Meorawr/Total-RP-3/runs/1259973133?check_suite_focus=true) in the `none` state that generated no check issues - just to show everything seems to still work in the best case scenario.

Note that the GitHub API limits the number of annotations generated during a run to a very small set of numbers (I believe it's 10 per step and 50 per run). If this is exceeded then the GitHub UI simply [won't store the ones beyond the limit](https://github.com/Meorawr/Total-RP-3/actions/runs/308940627), though [they'll still appear in the log file](https://github.com/Meorawr/Total-RP-3/runs/1260070540?check_suite_focus=true). The action won't bail due to the limits being exceeded.
