### PR TITLE
Hardcode library versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,8 @@ runs:
         echo "##[group]Install luacheck"
         if ! hash luacheck &>/dev/null; then
           sudo apt-get install -yq luarocks 1>/dev/null || exit 1
-          sudo luarocks install luacheck 1>/dev/null || exit 1
-          sudo luarocks install lanes &>/dev/null || true
+          sudo luarocks install luacheck 1.1.1-1 1>/dev/null || exit 1
+          sudo luarocks install lanes 3.16.0-0 &>/dev/null || true
         fi
         echo "##[command]luacheck --version"
         luacheck --version


### PR DESCRIPTION
3.16.1-0 of lanes contains a massive breaking bug. Seems wise to not automatically use the LATEST versions of libraries without validation, as it completely takes down any form of automated actions.