### PR TITLE
Update apt cache before installing luarocks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
     - run: |
         echo "##[group]Install luacheck"
         if ! hash luacheck &>/dev/null; then
+          sudo apt-get update 1>/dev/null || exit 1
           sudo apt-get install -yq luarocks 1>/dev/null || exit 1
           sudo luarocks install luacheck 1.1.1-1 1>/dev/null || exit 1
           sudo luarocks install lanes 3.16.0-0 &>/dev/null || true


### PR DESCRIPTION
The apt cache is not guaranteed to be updated when an action is started and in case of running under something like `act` it is guaranteed not to be. This resolves #5